### PR TITLE
fix: prevent work mode entity error on unsupported devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.0.2
+### Fixed
+- Fix work mode select entity failing with "Property does not exist" on unsupported devices
+- Only create work mode entity when device has the WorkModeSetting property
+- Add proper error handling for work mode set failures
+
 ## v1.0.1
 ### Added
 - New power sensors: generation power, total load power, battery power, grid total power

--- a/custom_components/hinen_power/manifest.json
+++ b/custom_components/hinen_power/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/Hinen-IoT/ha_hinen_power/issues",
   "quality_scale": "bronze",
   "requirements": ["hinen-open-api==1.0.0"],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/hinen_power/select.py
+++ b/custom_components/hinen_power/select.py
@@ -6,10 +6,12 @@ import logging
 from dataclasses import dataclass
 
 from hinen_open_api import HinenOpen
+from hinen_open_api.exceptions import HinenBackendError
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
@@ -57,6 +59,7 @@ async def async_setup_entry(
         HinenWorkModeSelect(coordinator, hinen_open, sensor_type, device_id)
         for device_id in coordinator.data
         for sensor_type in SELECT_TYPES
+        if coordinator.data[device_id].get(WORK_MODE_SETTING) is not None
     ]
 
     async_add_entities(entities)
@@ -70,14 +73,22 @@ class HinenWorkModeSelect(HinenDeviceEntity, SelectEntity):
     @property
     def available(self) -> bool:
         """Return if the entity is available."""
-        return True
+        if not self.coordinator.data:
+            return False
+        return (
+            self._device_id in self.coordinator.data
+            and self.coordinator.data[self._device_id].get(WORK_MODE_SETTING)
+            is not None
+        )
 
     @property
     def current_option(self) -> str | None:
         """Return the current work mode."""
         if not self.coordinator.data:
             return None
-        mode = self.coordinator.data[self._device_id][WORK_MODE_SETTING]
+        mode = self.coordinator.data[self._device_id].get(WORK_MODE_SETTING)
+        if mode is None:
+            return None
         _LOGGER.debug("current mode_value: %s", mode)
         return WORK_MODE_OPTIONS.get(mode, WORK_MODE_OPTIONS[WORK_MODE_NONE])
 
@@ -90,8 +101,13 @@ class HinenWorkModeSelect(HinenDeviceEntity, SelectEntity):
                 break
         _LOGGER.debug("mode_value: %s", mode_value)
         if mode_value is not None:
-            await self.hinen_open.set_property(
-                mode_value, self._device_id, PROPERTIES[WORK_MODE_SETTING]
-            )
+            try:
+                await self.hinen_open.set_property(
+                    mode_value, self._device_id, PROPERTIES[WORK_MODE_SETTING]
+                )
+            except HinenBackendError as err:
+                raise HomeAssistantError(
+                    f"Failed to set work mode: {err}"
+                ) from err
             self.coordinator.data[self._device_id][WORK_MODE_SETTING] = mode_value
             self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- Fixes work mode select entity failing with "Property does not exist" error on devices that don't support `WorkModeSetting`
- Only creates the work mode entity when the device actually has the `WorkModeSetting` property
- Adds proper error handling for `set_property` failures, raising `HomeAssistantError` with a clear message
- Bumps version to `1.0.2`

Closes #3

## Changes
- **`select.py`**: Added guard clause in entity creation to skip devices without `WorkModeSetting`, improved `available` property to check for property existence, used `.get()` for safe dictionary access in `current_option`, and wrapped `set_property` call in try/except to handle `HinenBackendError`
- **`manifest.json`**: Version bump to `1.0.2`
- **`CHANGELOG.md`**: Added v1.0.2 release notes

## Test plan
- [ ] Install on a system with a device that supports WorkModeSetting — verify entity is created and mode switching works
- [ ] Install on a system with a device that does NOT support WorkModeSetting — verify no work mode entity is created and no errors in logs
- [ ] Simulate a backend error when setting work mode — verify a clear `HomeAssistantError` is raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)